### PR TITLE
[typescript] prefer string enums instead of numeric enums

### DIFF
--- a/development/typescript.md
+++ b/development/typescript.md
@@ -23,9 +23,33 @@ const point: Point = { x: 1, y: 2 };
 type Partner = 'ExternalStore' | 'Merchant';
 // vs
 enum Partner {
-  ExternalStore,
-  Merchant,
+  ExternalStore = 'ExternalStore',
+  Merchant = 'Merchant',
 }
+```
+
+- String enums should be preferred to numeric enums which are unsafe.
+
+```typescript
+// bad
+enum NumericEnum {
+  first,
+  second = 1
+}
+
+declare function f(e: NumericEnum): void
+f(123) // this shouldn't compile but it does!
+
+// good
+enum StringEnum {
+  first = 'first',
+  second = 'second'
+}
+
+declare function f2(e: StringEnum): void
+f2(StringEnum.first) // OK
+f2('first') // not allowed
+f2('hello') // not allowed
 ```
 
 > Choose for consistency within a project.


### PR DESCRIPTION
I'd propose we encourage usage of string enums because numeric enums are not type safe.

Here's an [example](https://www.typescriptlang.org/play?ts=3.8.3#code/KYOwrgtgBAcpBGwBOBRc0DeAoKurwEMkAaHPQgLygF4oBGABgawF8sATYAYwBsjgoAMzAguAFwCWAexBQxwAM5iAFMABcsBMjSQAlBoBuUieyzylygEwBmACy6oAekdyAFhIVQFrqWB7sQAHIxKC4pCAAHCR5gYigAdwEZHgBPKFcCAwEDAh4wRSgGKGVCJAcCEHZ6JmLKXQBCLCxQSCgAZTEkCRAAcx1MMlxSmihA0sDSPHwCKloxmcDWDm4+JAFhUUkZOUUxS1UNDq7e-v0oIxMzXf2j7r70ADpSh2coAHkAaUbzPeV5pECLxcYSQa3EchSEQEyCQUiQVyU+0CrmAPB4UkBTmBcLBITEkOhoLhQA)
